### PR TITLE
Premove depends on locality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.class
+data

--- a/Ant.java
+++ b/Ant.java
@@ -86,7 +86,7 @@ public class Ant implements Steppable
             if(printStatus) System.out.println("nest Reached.");
         }
         else if (hasBeacon && canRemove(fwb, neighbors, hasFoodInRange, hasNestInRange)
-                 && fwb.random.nextDouble() <= Math.pow((-localityCount+tau)/tau,0.2)){
+                 && fwb.random.nextDouble() <= Math.pow((-localityCount+tau)/tau,0.5)){
             if(printStatus) System.out.println("removed beacon "+currBeacon);
             remove(beaconsPos);
         }

--- a/Ant.java
+++ b/Ant.java
@@ -116,7 +116,8 @@ public class Ant implements Steppable
             antsPos.setObjectLocation(this, currPos);
             if(printStatus) System.out.println("followed pheromone");
         }
-        else if (canDeploy(fwb) && fwb.random.nextDouble() < fwb.pDeploy){
+        //else if (canDeploy(fwb) && fwb.random.nextDouble() < fwb.pDeploy){
+        else if (canDeploy(fwb) && fwb.random.nextDouble() < Math.exp(-fwb.beaconsPos.size()/fwb.MAX_BEACON_NUMBER)){
             deploy(fwb);
             if(printStatus) System.out.println("deployed the beacon "+currBeacon );
         }
@@ -274,11 +275,12 @@ public class Ant implements Steppable
     public boolean canDeploy(ForagingWithBeacons state)
     {
         Continuous2D beaconsPos = state.beaconsPos;
+        /* CHANGED BY USING PDEPLOY(number of beacons)
         if (beaconsPos.size() >= state.MAX_BEACON_NUMBER) {
             //System.out.println("Max beacons reached.");
             return false;
         }
-
+        */
         for (int i = 0; i < DEPLOY_TRIES; i++){
             while (true){
                 double r = (state.random.nextDouble() *

--- a/Ant.java
+++ b/Ant.java
@@ -32,7 +32,7 @@ public class Ant implements Steppable
     int localityCount = 0;
     public int getLocalityCount() {return localityCount;}
     public Beacon getCurrentBeacon() {return currBeacon;}
-    double tau = 10;
+    double tau = 40;
     //whereToDeploy is needed to pass a value to deploy()
     Double2D whereToDeploy = new Double2D(0,0);
 
@@ -85,8 +85,8 @@ public class Ant implements Steppable
             //nest.foodRecovered += 1;
             if(printStatus) System.out.println("nest Reached.");
         }
-        else if (hasBeacon && canRemove(fwb, neighbors, hasFoodInRange, hasNestInRange)){
-                 //&& fwb.random.nextDouble() <= Math.exp(-localityCount/tau)){
+        else if (hasBeacon && canRemove(fwb, neighbors, hasFoodInRange, hasNestInRange)
+                 && fwb.random.nextDouble() <= Math.pow((-localityCount+tau)/tau,0.2)){
             if(printStatus) System.out.println("removed beacon "+currBeacon);
             remove(beaconsPos);
         }

--- a/ForagingWithBeacons.java
+++ b/ForagingWithBeacons.java
@@ -10,17 +10,17 @@ public class ForagingWithBeacons extends SimState
     public static boolean PRINT_ON_FILE = true;
     public static final int MAX_BEACON_NUMBER = 50;
     public static final double WORLD_SIZE = 100;
-    public static final double X_NEST = 20.0;
-    public static final double Y_NEST = 20.0;
+    public static final double X_NEST = 10.0;
+    public static final double Y_NEST = 10.0;
     public static final int MEAN_TIME = 50;
     public Continuous2D antsPos = new Continuous2D(1.0, WORLD_SIZE, WORLD_SIZE);
     public Continuous2D beaconsPos = new Continuous2D(1.0, WORLD_SIZE, WORLD_SIZE);
     public Continuous2D foodPos = new Continuous2D(1.0, WORLD_SIZE, WORLD_SIZE);
     public Continuous2D nestPos = new Continuous2D(1.0, WORLD_SIZE, WORLD_SIZE);
     double range = 10.0;
-    int antsNumber = 50;
+    int antsNumber = 100;
     double reward = 1.0;
-    double pExplore = 0.0001;
+    double pExplore = 0.001;
     double pFollow = 0.90;
     double pDeploy = 0.5;
     double pMove = 0.1;
@@ -40,9 +40,9 @@ public class ForagingWithBeacons extends SimState
     public Object domEvaporationConstant () { return new sim.util.Interval(0.0,1.0);}
     public Object domPExplore () { return new sim.util.Interval(0.0,1.0);}
     public Object domPFollow () { return new sim.util.Interval(0.0,1.0);}
-    public double getPDeploy(){return pDeploy;}
-    public void setPDeploy(double newConst){if (newConst >=0 && newConst <=1 ) pDeploy = newConst;}
-    public Object domPDeploy () { return new sim.util.Interval(0.0,1.0);}
+    //public double getPDeploy(){return pDeploy;}
+    //public void setPDeploy(double newConst){if (newConst >=0 && newConst <=1 ) pDeploy = newConst;}
+    //public Object domPDeploy () { return new sim.util.Interval(0.0,1.0);}
     public Object domPMove () { return new sim.util.Interval(0.0,1.0);}
     public double getPMove(){return pMove;}
     public void setPMove(double newP) {if (newP >=0 && newP <=1) pMove = newP;}
@@ -91,13 +91,13 @@ public class ForagingWithBeacons extends SimState
 
         //New part to create data files
         if (PRINT_ON_FILE){
-            schedule.scheduleRepeating(schedule.EPOCH,1, new Steppable(){
+            schedule.scheduleRepeating(schedule.EPOCH,2, new Steppable(){
                     public void step (SimState state)
                     {
                         ForagingWithBeacons fwb = (ForagingWithBeacons) state;
                         Nest nest =(Nest)(fwb.nestPos.getAllObjects().get(0));
                         try(BufferedWriter bw = new BufferedWriter(new FileWriter("data/"+seed()+".csv",true))){
-                            bw.write(fwb.schedule.time()+","+nest.foodRecovered+","+fwb.beaconsPos.size()+"\n");
+                            bw.write(fwb.schedule.time()+","+nest.foodIncomingRate+","+fwb.beaconsPos.size()+","+nest.meanTravelLength+"\n");
                         }
                         catch(IOException e){}
                     }

--- a/ForagingWithBeacons.java
+++ b/ForagingWithBeacons.java
@@ -18,7 +18,7 @@ public class ForagingWithBeacons extends SimState
     double reward = 1.0;
     double pExplore = 0.0001;
     double pFollow = 0.90;
-    double pDeploy = 0.9;
+    double pDeploy = 0.5;
     double pMove = 0.1;
     int countMax = 5;
     public double evaporationConstant = 0.95;
@@ -39,6 +39,13 @@ public class ForagingWithBeacons extends SimState
     public double getPDeploy(){return pDeploy;}
     public void setPDeploy(double newConst){if (newConst >=0 && newConst <=1 ) pDeploy = newConst;}
     public Object domPDeploy () { return new sim.util.Interval(0.0,1.0);}
+    public Object domPMove () { return new sim.util.Interval(0.0,1.0);}
+    public double getPMove(){return pMove;}
+    public void setPMove(double newP) {if (newP >=0 && newP <=1) pMove = newP;}
+
+
+    public int getBeaconsNumber(){return beaconsPos.size();}
+
 
     public ForagingWithBeacons(long seed)
     {

--- a/ForagingWithBeacons.java
+++ b/ForagingWithBeacons.java
@@ -1,14 +1,18 @@
 import sim.engine.*;
 import sim.util.*;
 import sim.field.continuous.*;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
 
 public class ForagingWithBeacons extends SimState
 {
-    public static final int MAX_BEACON_NUMBER = 70;
+    public static boolean PRINT_ON_FILE = true;
+    public static final int MAX_BEACON_NUMBER = 50;
     public static final double WORLD_SIZE = 100;
     public static final double X_NEST = 20.0;
     public static final double Y_NEST = 20.0;
-    public static final int MEAN_TIME = 20;
+    public static final int MEAN_TIME = 50;
     public Continuous2D antsPos = new Continuous2D(1.0, WORLD_SIZE, WORLD_SIZE);
     public Continuous2D beaconsPos = new Continuous2D(1.0, WORLD_SIZE, WORLD_SIZE);
     public Continuous2D foodPos = new Continuous2D(1.0, WORLD_SIZE, WORLD_SIZE);
@@ -84,6 +88,21 @@ public class ForagingWithBeacons extends SimState
         nestPos.setObjectLocation(nest, new Double2D(X_NEST, Y_NEST));
         schedule.scheduleRepeating(schedule.EPOCH, 1, nest, MEAN_TIME);
         foodPos.setObjectLocation(new Food(), new Double2D(90.0, 90.0));
+
+        //New part to create data files
+        if (PRINT_ON_FILE){
+            schedule.scheduleRepeating(schedule.EPOCH,1, new Steppable(){
+                    public void step (SimState state)
+                    {
+                        ForagingWithBeacons fwb = (ForagingWithBeacons) state;
+                        Nest nest =(Nest)(fwb.nestPos.getAllObjects().get(0));
+                        try(BufferedWriter bw = new BufferedWriter(new FileWriter("data/"+seed()+".csv",true))){
+                            bw.write(fwb.schedule.time()+","+nest.foodRecovered+","+fwb.beaconsPos.size()+"\n");
+                        }
+                        catch(IOException e){}
+                    }
+                },MEAN_TIME);
+        }
     }
     public static void main(String[] args)
     {

--- a/ForagingWithBeaconsUI.java
+++ b/ForagingWithBeaconsUI.java
@@ -23,7 +23,13 @@ public class ForagingWithBeaconsUI extends GUIState
         c.setVisible(true);
     }
     public ForagingWithBeaconsUI()
-    {super(new ForagingWithBeacons(System.currentTimeMillis()));}
+    {
+        super(new ForagingWithBeacons(System.currentTimeMillis()));
+
+        //added to remove the printed on file data when using the GUI
+        ForagingWithBeacons sim = (ForagingWithBeacons)state;
+        sim.PRINT_ON_FILE = false;
+    }
     public ForagingWithBeaconsUI(SimState state){super(state);}
 
     public Object getSimulationInspectedObject() {return state;}
@@ -37,6 +43,7 @@ public class ForagingWithBeaconsUI extends GUIState
     public static String getName() { return "Foraging with beacons project";}
     public void start()
     {
+
         super.start();
         setupPortrayals();
     }


### PR DESCRIPTION
As a reasonable fix to unstuck ants from unconnected nets of beacons the choice of modifying pRemove with a dependency on a locality parameter is included in the main project. Further additions done in this branch were supposed to be added directly to the main branch